### PR TITLE
RFC: Handle comments in proxy fallback values

### DIFF
--- a/src/main/java/io/sf/carte/doc/style/css/nsac/LexicalUnit.java
+++ b/src/main/java/io/sf/carte/doc/style/css/nsac/LexicalUnit.java
@@ -458,25 +458,56 @@ public interface LexicalUnit {
 	short getCssUnit();
 
 	/**
-	 * The next lexical unit.
+	 * The next non-{@code EMPTY} lexical unit.
 	 * <p>
 	 * Lexical units can form chains of units which can be traversed with
-	 * {@code getNextLexicalUnit()} and {@link #getPreviousLexicalUnit()}.
+	 * {@code getNextLexicalUnit()}, {@link #getPreviousLexicalUnit()} and their raw
+	 * counterparts (which return all units including {@code EMPTY} units).
+	 * </p>
+	 * <p>
+	 * If the next unit is {@code EMPTY} the next non-{@code EMPTY} unit will be
+	 * returned, or {@code null} if none.
 	 * </p>
 	 * 
-	 * @return the next lexical unit, or <code>null</code> if none.
+	 * @return the next non-{@code EMPTY} lexical unit, or <code>null</code> if
+	 *         none.
 	 */
 	LexicalUnit getNextLexicalUnit();
 
 	/**
-	 * The previous lexical unit.
+	 * The next lexical unit.
+	 * <p>
+	 * Lexical units can form chains of units which can be traversed with
+	 * {@code getNextRawLexicalUnit()}, {@link #getPreviousRawLexicalUnit()} and
+	 * their non-raw counterparts (which skip {@code EMPTY} units).
+	 * </p>
+	 * 
+	 * @return the next lexical unit (could be an {@code EMPTY} unit), or
+	 *         <code>null</code> if none.
+	 */
+	LexicalUnit getNextRawLexicalUnit();
+
+	/**
+	 * The previous non-{@code EMPTY} lexical unit.
 	 * <p>
 	 * See also {@link #getNextLexicalUnit}.
 	 * </p>
 	 * 
-	 * @return the previous lexical unit, or <code>null</code> if none.
+	 * @return the previous non-{@code EMPTY} lexical unit, or <code>null</code> if
+	 *         none.
 	 */
 	LexicalUnit getPreviousLexicalUnit();
+
+	/**
+	 * The previous lexical unit.
+	 * <p>
+	 * See also {@link #getNextRawLexicalUnit}.
+	 * </p>
+	 * 
+	 * @return the previous lexical unit (could be an {@code EMPTY} unit), or
+	 *         <code>null</code> if none.
+	 */
+	LexicalUnit getPreviousRawLexicalUnit();
 
 	/**
 	 * Insert the given unit as the next lexical unit.

--- a/src/main/java/io/sf/carte/doc/style/css/property/AttrValue.java
+++ b/src/main/java/io/sf/carte/doc/style/css/property/AttrValue.java
@@ -244,6 +244,10 @@ public class AttrValue extends ProxyValue implements CSSAttrValue {
 
 			LexicalUnit lu = lunit.getParameters();
 
+			if (lu == null) {
+				throw new DOMException(DOMException.SYNTAX_ERR, "Invalid attr() name.");
+			}
+
 			LexicalType type = lu.getLexicalUnitType();
 			if (type == LexicalType.IDENT) {
 				attrname = lu.getStringValue();
@@ -290,19 +294,18 @@ public class AttrValue extends ProxyValue implements CSSAttrValue {
 				}
 				// Move past comma
 				lu = lu.getNextLexicalUnit();
-				if (lu == null) {
-					wrongSyntax(lunit);
-				}
-				// Check the fallback
-				type = lu.getLexicalUnitType();
-				ValueFactory factory = new ValueFactory(flags);
-				try {
-					fallback = factory.createCSSValue(lu.clone(), null, false);
-				} catch (RuntimeException e) {
-					DOMException ex = new DOMException(DOMException.TYPE_MISMATCH_ERR,
-							"Invalid fallback: " + fallback.toString());
-					ex.initCause(e);
-					throw ex;
+				if (lu != null) {
+					// Check the fallback
+					type = lu.getLexicalUnitType();
+					ValueFactory factory = new ValueFactory(flags);
+					try {
+						fallback = factory.createCSSValue(lu.clone(), null, false);
+					} catch (RuntimeException e) {
+						DOMException ex = new DOMException(DOMException.TYPE_MISMATCH_ERR,
+								"Invalid fallback: " + fallback.toString());
+						ex.initCause(e);
+						throw ex;
+					}
 				}
 			}
 

--- a/src/main/java/io/sf/carte/doc/style/css/property/LexicalValue.java
+++ b/src/main/java/io/sf/carte/doc/style/css/property/LexicalValue.java
@@ -299,6 +299,7 @@ public class LexicalValue extends ProxyValue implements CSSLexicalValue {
 			case LEFT_BRACKET:
 			case OPERATOR_COMMA:
 			case OPERATOR_SEMICOLON:
+			case EMPTY:
 				needSpaces = false;
 				break;
 			case RIGHT_BRACKET:
@@ -312,7 +313,7 @@ public class LexicalValue extends ProxyValue implements CSSLexicalValue {
 				}
 			}
 			buf.append(serializeMinified(lu));
-			lu = lu.getNextLexicalUnit();
+			lu = lu.getNextRawLexicalUnit();
 		}
 		return buf.toString();
 	}

--- a/src/main/java/io/sf/carte/doc/style/css/property/MathFunctionValue.java
+++ b/src/main/java/io/sf/carte/doc/style/css/property/MathFunctionValue.java
@@ -18,6 +18,7 @@ import io.sf.carte.doc.style.css.CSSUnit;
 import io.sf.carte.doc.style.css.CSSValueSyntax;
 import io.sf.carte.doc.style.css.CSSValueSyntax.Category;
 import io.sf.carte.doc.style.css.CSSValueSyntax.Match;
+import io.sf.carte.doc.style.css.nsac.LexicalUnit;
 
 /**
  * Implementation of a mathematical function value.
@@ -41,6 +42,11 @@ class MathFunctionValue extends FunctionValue implements CSSMathFunctionValue {
 	@Override
 	public MathFunction getFunction() {
 		return function;
+	}
+
+	@Override
+	ValueItem processEmptyLexicalUnit(ValueFactory factory, LexicalUnit lu) {
+		return null;
 	}
 
 	/**

--- a/src/main/java/io/sf/carte/doc/style/css/property/ValueFactory.java
+++ b/src/main/java/io/sf/carte/doc/style/css/property/ValueFactory.java
@@ -805,18 +805,22 @@ public class ValueFactory {
 	/**
 	 * Creates a LexicalSetter according to the given lexical value.
 	 * <p>
-	 * This method either returns a value or throws an exception, but cannot return null.
+	 * This method either returns a value or throws an exception, but cannot return
+	 * {@code null}.
+	 * </p>
+	 * <p>
+	 * If the lexical unit is {@code EMPTY}, will return the setter for the next
+	 * non-empty unit, if any, otherwise a setter containing {@code EMPTY}.
 	 * </p>
 	 * 
-	 * @param lunit
-	 *            the lexical value.
-	 * @param ratioContext
-	 *            {@code true} if we are in a context where ratio values could be expected.
-	 * @param subp
-	 *            the flag marking whether it is a sub-property.
-	 * @return the LexicalSetter for the CSS primitive value.
-	 * @throws DOMException
-	 *             if a problem was found setting the lexical value to a CSS primitive.
+	 * @param lunit        the lexical value.
+	 * @param ratioContext {@code true} if we are in a context where ratio values
+	 *                     could be expected.
+	 * @param subp         the flag marking whether it is a sub-property.
+	 * @return the LexicalSetter for the CSS primitive value, or {@code null} and
+	 *         isn't followed by any non-empty units.
+	 * @throws DOMException if a problem was found setting the lexical value to a
+	 *                      CSS primitive.
 	 */
 	LexicalSetter createCSSPrimitiveValueItem(LexicalUnit lunit, boolean ratioContext, boolean subp)
 			throws DOMException {
@@ -961,10 +965,6 @@ public class ValueFactory {
 				primi = new ColorMixFunction();
 				(setter = primi.newLexicalSetter()).setLexicalUnit(lunit);
 				break;
-			case EMPTY:
-				primi = new LexicalValue();
-				(setter = primi.newLexicalSetter()).setLexicalUnit(lunit);
-				break;
 			case ATTR:
 				primi = new AttrValue(flags);
 				(setter = primi.newLexicalSetter()).setLexicalUnit(lunit);
@@ -1000,6 +1000,14 @@ public class ValueFactory {
 				break;
 			case ELEMENT_REFERENCE:
 				primi = new ElementReferenceValue();
+				(setter = primi.newLexicalSetter()).setLexicalUnit(lunit);
+				break;
+			case EMPTY:
+				LexicalUnit nlu = lunit.getNextLexicalUnit();
+				if (nlu != null) {
+					return createCSSPrimitiveValueItem(nlu, ratioContext, subp);
+				}
+				primi = new LexicalValue();
 				(setter = primi.newLexicalSetter()).setLexicalUnit(lunit);
 				break;
 			case OPERATOR_COMMA:

--- a/src/test/java/io/sf/carte/doc/style/css/parser/PropertyParserTest.java
+++ b/src/test/java/io/sf/carte/doc/style/css/parser/PropertyParserTest.java
@@ -4313,6 +4313,70 @@ public class PropertyParserTest {
 	}
 
 	@Test
+	public void testParsePropertyValueAttrCommentName() throws CSSException {
+		LexicalUnit lu = parsePropertyValue("attr(/*!*/data-count)");
+		assertEquals(LexicalType.ATTR, lu.getLexicalUnitType());
+		assertEquals("attr", lu.getFunctionName());
+		LexicalUnit param = lu.getParameters();
+		assertNotNull(param);
+		assertEquals(LexicalType.IDENT, param.getLexicalUnitType());
+		assertEquals("data-count", param.getStringValue());
+		assertNull(param.getNextLexicalUnit());
+		assertEquals("attr(data-count)", lu.toString());
+	}
+
+	@Test
+	public void testParsePropertyValueAttrNameComment() throws CSSException {
+		LexicalUnit lu = parsePropertyValue("attr(data-count/*!*/)");
+		assertEquals(LexicalType.ATTR, lu.getLexicalUnitType());
+		assertEquals("attr", lu.getFunctionName());
+		LexicalUnit param = lu.getParameters();
+		assertNotNull(param);
+		assertEquals(LexicalType.IDENT, param.getLexicalUnitType());
+		assertEquals("data-count", param.getStringValue());
+		assertNull(param.getNextLexicalUnit());
+		assertEquals("attr(data-count)", lu.toString());
+	}
+
+	@Test
+	public void testParsePropertyValueAttrCommentFallback() throws CSSException {
+		LexicalUnit lu = parsePropertyValue("attr(data-count, /*!*/)");
+		assertEquals(LexicalType.ATTR, lu.getLexicalUnitType());
+		assertEquals("attr", lu.getFunctionName());
+		LexicalUnit param = lu.getParameters();
+		assertNotNull(param);
+		assertEquals(LexicalType.IDENT, param.getLexicalUnitType());
+		assertEquals("data-count", param.getStringValue());
+		param = param.getNextLexicalUnit();
+		assertNotNull(param);
+		assertEquals(LexicalType.OPERATOR_COMMA, param.getLexicalUnitType());
+		param = param.getNextRawLexicalUnit();
+		assertNotNull(param);
+		assertEquals(LexicalType.EMPTY, param.getLexicalUnitType());
+		assertEquals("/*!*/", param.getCssText());
+		assertSame(param.getPreviousLexicalUnit(), param.getPreviousRawLexicalUnit());
+		assertNull(param.getNextLexicalUnit());
+		assertEquals("attr(data-count, /*!*/)", lu.toString());
+		//
+		CSSValueSyntax syn = syntaxParser.parseSyntax("<string>");
+		assertEquals(Match.PENDING, lu.matches(syn));
+		syn = syntaxParser.parseSyntax("<string>#");
+		assertEquals(Match.PENDING, lu.matches(syn));
+		syn = syntaxParser.parseSyntax("<string>+");
+		assertEquals(Match.PENDING, lu.matches(syn));
+		syn = syntaxParser.parseSyntax("<color>");
+		assertEquals(Match.FALSE, lu.matches(syn));
+		syn = syntaxParser.parseSyntax("<custom-ident> | <string>#");
+		assertEquals(Match.PENDING, lu.matches(syn));
+		syn = syntaxParser.parseSyntax("<custom-ident> | <string>+");
+		assertEquals(Match.PENDING, lu.matches(syn));
+		syn = syntaxParser.parseSyntax("<custom-ident> | <string>");
+		assertEquals(Match.PENDING, lu.matches(syn));
+		syn = syntaxParser.parseSyntax("*");
+		assertEquals(Match.TRUE, lu.matches(syn));
+	}
+
+	@Test
 	public void testParsePropertyValueAttrPcnt() throws CSSException {
 		LexicalUnit lu = parsePropertyValue("attr(data-count percentage)");
 		assertEquals(LexicalType.ATTR, lu.getLexicalUnitType());
@@ -5349,7 +5413,7 @@ public class PropertyParserTest {
 		param = param.getNextLexicalUnit();
 		assertNotNull(param);
 		assertEquals(LexicalType.OPERATOR_COMMA, param.getLexicalUnitType());
-		param = param.getNextLexicalUnit();
+		param = param.getNextRawLexicalUnit();
 		assertNotNull(param);
 		assertEquals(LexicalType.EMPTY, param.getLexicalUnitType());
 		assertEquals("", param.getCssText());
@@ -5368,6 +5432,68 @@ public class PropertyParserTest {
 		assertEquals(Match.PENDING, lu.matches(syn));
 		syn = syntaxParser.parseSyntax("*");
 		assertEquals(Match.TRUE, lu.matches(syn));
+	}
+
+	@Test
+	public void testParsePropertyValueVarCommentFallback() throws CSSException {
+		LexicalUnit lu = parsePropertyValue("var(--data-radius, /*¡*//*!*/)");
+		assertEquals(LexicalType.VAR, lu.getLexicalUnitType());
+		assertEquals("var", lu.getFunctionName());
+		LexicalUnit param = lu.getParameters();
+		assertNotNull(param);
+		assertEquals(LexicalType.IDENT, param.getLexicalUnitType());
+		assertEquals("--data-radius", param.getStringValue());
+		param = param.getNextLexicalUnit();
+		assertNotNull(param);
+		assertEquals(LexicalType.OPERATOR_COMMA, param.getLexicalUnitType());
+		param = param.getNextRawLexicalUnit();
+		assertNotNull(param);
+		assertEquals(LexicalType.EMPTY, param.getLexicalUnitType());
+		assertEquals("/*¡*/", param.getCssText());
+		param = param.getNextRawLexicalUnit();
+		assertNotNull(param);
+		assertEquals(LexicalType.EMPTY, param.getLexicalUnitType());
+		assertNull(param.getNextRawLexicalUnit());
+		assertEquals("var(--data-radius, /*¡*//*!*/)", lu.toString());
+
+		CSSValueSyntax syn = syntaxParser.parseSyntax("<percentage>");
+		assertEquals(Match.PENDING, lu.matches(syn));
+		syn = syntaxParser.parseSyntax("<length-percentage>");
+		assertEquals(Match.PENDING, lu.matches(syn));
+		syn = syntaxParser.parseSyntax("<percentage>#");
+		assertEquals(Match.PENDING, lu.matches(syn));
+		syn = syntaxParser.parseSyntax("<percentage>+");
+		assertEquals(Match.PENDING, lu.matches(syn));
+		syn = syntaxParser.parseSyntax("<color>");
+		assertEquals(Match.PENDING, lu.matches(syn));
+		syn = syntaxParser.parseSyntax("*");
+		assertEquals(Match.TRUE, lu.matches(syn));
+	}
+
+	@Test
+	public void testParsePropertyValueVarCommentName() throws CSSException {
+		LexicalUnit lu = parsePropertyValue("var(/*!*/--data-radius)");
+		assertEquals(LexicalType.VAR, lu.getLexicalUnitType());
+		assertEquals("var", lu.getFunctionName());
+		LexicalUnit param = lu.getParameters();
+		assertNotNull(param);
+		assertEquals(LexicalType.IDENT, param.getLexicalUnitType());
+		assertEquals("--data-radius", param.getStringValue());
+		assertNull(param.getNextLexicalUnit());
+		assertEquals("var(--data-radius)", lu.toString());
+	}
+
+	@Test
+	public void testParsePropertyValueVarNameComment() throws CSSException {
+		LexicalUnit lu = parsePropertyValue("var(--data-radius/*!*/)");
+		assertEquals(LexicalType.VAR, lu.getLexicalUnitType());
+		assertEquals("var", lu.getFunctionName());
+		LexicalUnit param = lu.getParameters();
+		assertNotNull(param);
+		assertEquals(LexicalType.IDENT, param.getLexicalUnitType());
+		assertEquals("--data-radius", param.getStringValue());
+		assertNull(param.getNextLexicalUnit());
+		assertEquals("var(--data-radius)", lu.toString());
 	}
 
 	@Test

--- a/src/test/java/io/sf/carte/doc/style/css/property/AttrValueTest.java
+++ b/src/test/java/io/sf/carte/doc/style/css/property/AttrValueTest.java
@@ -487,6 +487,17 @@ public class AttrValueTest {
 	}
 
 	@Test
+	public void testParseAttrCommentFallback() {
+		BaseCSSStyleDeclaration style = createStyleDeclaration();
+		style.setCssText("margin-left:attr(leftmargin percentage,/*!*/)");
+		StyleValue marginLeft = style.getPropertyCSSValue("margin-left");
+		assertNotNull(marginLeft);
+		assertEquals("attr(leftmargin percentage)", marginLeft.getCssText());
+		assertFalse(style.getStyleDeclarationErrorHandler().hasErrors());
+		assertFalse(style.getStyleDeclarationErrorHandler().hasWarnings());
+	}
+
+	@Test
 	public void testParseFallbackCustomPropertyRecursiveAttr() {
 		BaseCSSStyleDeclaration style = createStyleDeclaration();
 		style.setCssText("margin-left:attr(noattr length,var(--foo,attr(noattr)))");

--- a/src/test/java/io/sf/carte/doc/style/css/property/LexicalValueTest.java
+++ b/src/test/java/io/sf/carte/doc/style/css/property/LexicalValueTest.java
@@ -320,6 +320,34 @@ public class LexicalValueTest {
 	}
 
 	@Test
+	public void testAttrComments() {
+		BaseCSSStyleDeclaration style = new BaseCSSStyleDeclaration();
+		style.setCssText("--foo:attr(data-bar,/*¡*//*!*/);");
+		StyleValue cssval = style.getPropertyCSSValue("--foo");
+		assertEquals("attr(data-bar, /*¡*//*!*/)", cssval.getCssText());
+		assertEquals("attr(data-bar,/*¡*//*!*/)", cssval.getMinifiedCssText(""));
+		assertEquals(CssType.PROXY, cssval.getCssValueType());
+		assertEquals(Type.LEXICAL, cssval.getPrimitiveType());
+		assertEquals(Type.UNKNOWN, ((LexicalValue) cssval).getFinalType());
+		assertEquals("--foo: attr(data-bar, /*¡*//*!*/);\n", style.getCssText());
+		assertEquals("--foo:attr(data-bar,/*¡*//*!*/)", style.getMinifiedCssText());
+	}
+
+	@Test
+	public void testVarComments() {
+		BaseCSSStyleDeclaration style = new BaseCSSStyleDeclaration();
+		style.setCssText("--foo:var(--bar,/*¡*//*!*/);");
+		StyleValue cssval = style.getPropertyCSSValue("--foo");
+		assertEquals("var(--bar, /*¡*//*!*/)", cssval.getCssText());
+		assertEquals("var(--bar,/*¡*//*!*/)", cssval.getMinifiedCssText(""));
+		assertEquals(CssType.PROXY, cssval.getCssValueType());
+		assertEquals(Type.LEXICAL, cssval.getPrimitiveType());
+		assertEquals(Type.UNKNOWN, ((LexicalValue) cssval).getFinalType());
+		assertEquals("--foo: var(--bar, /*¡*//*!*/);\n", style.getCssText());
+		assertEquals("--foo:var(--bar,/*¡*//*!*/)", style.getMinifiedCssText());
+	}
+
+	@Test
 	public void testURI_Var() {
 		BaseCSSStyleDeclaration style = new BaseCSSStyleDeclaration();
 		style.setCssText("background-image:url(var(--myURI));");


### PR DESCRIPTION
Support comments in fallback values, like:
```css
property: var(--foo, /*a*//*b*/);
```
or
```css
property: attr(data-foo ident, /*a*//*b*/);
```
This involves the new `getNextRawLexicalUnit()` and `getPreviousRawLexicalUnit()` methods in `LexicalUnit`.

The old `getNextLexicalUnit()` and `getPreviousLexicalUnit()` behave as always, ignoring comments, while the new Raw variants may return `EMPTY` lexical units that were produced by comments.

<br />

## Justification

I found that some people are using comments in `var()` fallback values, and I assume that it is a strategy to force feed empty values into lexical substitution (despite the fact that the specification says that one only needs an empty fallback).

**This PR is unlikely to be merged unless users express some interest, given that it introduces significant overhead for no real gains.**